### PR TITLE
支援使用 CloudFlare CDN 可取得正確訪客 IP

### DIFF
--- a/lib/lib_common.php
+++ b/lib/lib_common.php
@@ -347,6 +347,11 @@ function getRemoteAddrOpenShift() {
     return '';
 }
 
+/**
+ * 若來源是 CloudFlare IP, 從 CF-Connecting-IP 取得 client IP
+ * CloudFlare IP 來源: https://www.cloudflare.com/ips
+*/
+
 function getRemoteAddrCloudFlare() {
     $addr = filter_input(INPUT_SERVER, 'REMOTE_ADDR');
     $cloudflare_v4 = array('199.27.128.0/21', '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22', '141.101.64.0/18', '108.162.192.0/18', '190.93.240.0/20', '188.114.96.0/20', '197.234.240.0/22', '198.41.128.0/17', '162.158.0.0/15', '104.16.0.0/12');


### PR DESCRIPTION
如果用 CloudFlare 當 CDN
可以從來源IP判斷是否為 cloudFlare 來
是的話 CF-Connecting-IP header 的 IP 就有可信度
