### PR TITLE
Added drone.io build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Pixmicat! Imageboard System
+Pixmicat! Imageboard System [![Build Status](https://drone.io/github.com/scribetw/pixmicat/status.png)](https://drone.io/github.com/scribetw/pixmicat/latest)
 ========
 
 What is this?


### PR DESCRIPTION
使用 https://drone.io/ 作為持續整合。